### PR TITLE
Adding an NMSRootRegistry object

### DIFF
--- a/api/src/main/java/de/verdox/mccreativelab/wrapper/annotations/MCCBuiltIn.java
+++ b/api/src/main/java/de/verdox/mccreativelab/wrapper/annotations/MCCBuiltIn.java
@@ -1,7 +1,7 @@
 package de.verdox.mccreativelab.wrapper.annotations;
 
 /**
- * Specifies that this type of minecraft element is hard coded into the game.
+ * Indicates that this type of minecraft element is hard coded into the game.
  */
 public @interface MCCBuiltIn {
     /**
@@ -32,6 +32,8 @@ public @interface MCCBuiltIn {
         /**
          * Fully synced. This element is always sent to the player.
          * Elements do not automatically count as synced if the client knows them at the same time as the server, but they never exchange them (e.g. BlockSoundGroups).
+         * If elements are synced this means that we cannot add new elements to the server without creating an incompatibility between client and server.
+         * Thus, other strategies must be implemented to overcome this problem. These strategies differ based on the element.
          */
         SYNCED,
         /**

--- a/api/src/main/java/de/verdox/mccreativelab/wrapper/platform/factory/TypedKeyFactory.java
+++ b/api/src/main/java/de/verdox/mccreativelab/wrapper/platform/factory/TypedKeyFactory.java
@@ -36,15 +36,62 @@ public interface TypedKeyFactory {
      * @return the typed key
      */
     <T> MCCTypedKey<T> getKey(Key key, Key registryKey, TypeToken<T> type);
+
+    /**
+     * Creates a typed key
+     *
+     * @param key         the key of the typed key
+     * @param registryKey the key of registry
+     * @param <T>         the generic wrapped type
+     * @return the typed key
+     */
     <T> MCCTypedKey<T> getKey(Key key, Key registryKey);
 
+    /**
+     * Creates a tag for a specific type
+     *
+     * @param key         the key of the typed key
+     * @param registryKey the key of registry
+     * @param type        the type
+     * @param <T>         the generic wrapped type
+     * @return the tag
+     */
     <T> MCCTag<T> createTag(Key key, Key registryKey, TypeToken<T> type);
+
+    /**
+     * Creates a tag
+     *
+     * @param key         the key of the typed key
+     * @param registryKey the key of registry
+     * @param <T>         the generic wrapped type
+     * @return the tag
+     */
     <T> MCCTag<T> createTag(Key key, Key registryKey);
 
+    /**
+     * Creates an immutable set without a key
+     *
+     * @param <T>         the generic wrapped type
+     * @return the immutable set without key
+     */
     <T> MCCReferenceSet<T> createImmutableSetWithoutKey(List<MCCReference<T>> references);
 
+    /**
+     * Creates an unbound tag
+     * @param key the key of the tag
+     * @param values the values of the tag
+     * @return the tag
+     * @param <T> the generic wrapped type
+     */
     <T> MCCTag<T> createUnboundTag(Key key, Collection<T> values);
 
+    /**
+     * Creates an unbound tag
+     * @param key the key of the tag
+     * @param values the values of the tag
+     * @return the tag
+     * @param <T> the generic wrapped type
+     */
     default <T> MCCTag<T> createUnboundTag(Key key, T... values) {
         return createUnboundTag(key, Set.of(values));
     }
@@ -54,35 +101,35 @@ public interface TypedKeyFactory {
         private final Key key;
         private final TypeToken<T> tagType;
 
-        public UnboundTagBuilder(Key key, TypeToken<T> tagType){
+        public UnboundTagBuilder(Key key, TypeToken<T> tagType) {
             this.key = key;
             this.tagType = tagType;
         }
 
-        public UnboundTagBuilder<T> with(T value){
+        public UnboundTagBuilder<T> with(T value) {
             this.values.add(value);
             return this;
         }
 
-        public UnboundTagBuilder<T> with(MCCReference<T> value){
+        public UnboundTagBuilder<T> with(MCCReference<T> value) {
             return with(value.get());
         }
 
-        public UnboundTagBuilder<T> with(T... values){
+        public UnboundTagBuilder<T> with(T... values) {
             this.values.addAll(Arrays.stream(values).toList());
             return this;
         }
 
-        public UnboundTagBuilder<T> with(Collection<T> values){
+        public UnboundTagBuilder<T> with(Collection<T> values) {
             this.values.addAll(values);
             return this;
         }
 
-        public UnboundTagBuilder<T> with(MCCTag<T> tag){
+        public UnboundTagBuilder<T> with(MCCTag<T> tag) {
             return with(tag.getValues().stream().map(MCCReference::get).collect(Collectors.toSet()));
         }
 
-        public MCCTag<T> build(){
+        public MCCTag<T> build() {
             return MCCPlatform.getInstance().getTypedKeyFactory().createUnboundTag(key, values);
         }
     }

--- a/api/src/main/java/de/verdox/mccreativelab/wrapper/platform/factory/TypedKeyFactory.java
+++ b/api/src/main/java/de/verdox/mccreativelab/wrapper/platform/factory/TypedKeyFactory.java
@@ -7,6 +7,7 @@ import de.verdox.mccreativelab.wrapper.registry.MCCReferenceSet;
 import de.verdox.mccreativelab.wrapper.registry.MCCTag;
 import de.verdox.mccreativelab.wrapper.registry.MCCTypedKey;
 import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -15,6 +16,16 @@ import java.util.stream.Collectors;
  * Used to create typed keys
  */
 public interface TypedKeyFactory {
+    @NotNull Key REGISTRY_OF_REGISTRIES = Key.key("minecraft", "root");
+
+    default <T> MCCTypedKey<T> getRegistryKey(String registryKey, TypeToken<T> type){
+        return getKey(Key.key("minecraft", registryKey), REGISTRY_OF_REGISTRIES, type);
+    }
+
+    default <T> MCCTypedKey<T> getRegistryKey(String registryKey){
+        return getKey(Key.key("minecraft", registryKey), REGISTRY_OF_REGISTRIES);
+    }
+
     /**
      * Creates a typed key for a specific type
      *

--- a/api/src/main/java/de/verdox/mccreativelab/wrapper/typed/MCCRegistries.java
+++ b/api/src/main/java/de/verdox/mccreativelab/wrapper/typed/MCCRegistries.java
@@ -36,24 +36,28 @@ public interface MCCRegistries {
     // MemoryModuleType
     // FrogVariant
 
+    MCCTypedKey<MCCRegistry<MCCAttribute>> ATTRIBUTE_REGISTRY = builtIn("attribute", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCBlockType>> BLOCK_REGISTRY = builtIn("block", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCItemType>> ITEM_REGISTRY = builtIn("item", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCDataComponentType<?>>> DATA_COMPONENT_REGISTRY = builtIn("data_component_type", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCDataComponentType<?>>> ENCHANTMENT_EFFECT_COMPONENT_TYPE_REGISTRY = builtIn("enchantment_effect_component_type", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCEffectType>> EFFECT_TYPE_REGISTRY = builtIn("mob_effect", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCMenuType<?>>> MENU_REGISTRY = builtIn("menu", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCGameEvent>> GAME_EVENT_REGISTRY = builtIn("game_event", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCPoiType>> POI_TYPE_REGISTRY = builtIn("point_of_interest_type", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCPotion>> POTION_REGISTRY = builtIn("potion", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCVillagerProfession>> VILLAGER_PROFESSION_REGISTRY = builtIn("villager_profession", new TypeToken<>() {});
 
-    MCCTypedKey<MCCRegistry<MCCAttribute>> ATTRIBUTE_REGISTRY = registry("attribute", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCBlockType>> BLOCK_REGISTRY = registry("block", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCItemType>> ITEM_REGISTRY = registry("item", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCDataComponentType<?>>> DATA_COMPONENT_REGISTRY = registry("data_component_type", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCDataComponentType<?>>> ENCHANTMENT_EFFECT_COMPONENT_TYPE_REGISTRY = registry("enchantment_effect_component_type", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCEffectType>> EFFECT_TYPE_REGISTRY = registry("mob_effect", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCMenuType<?>>> MENU_REGISTRY = registry("menu", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCGameEvent>> GAME_EVENT_REGISTRY = registry("game_event", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCInstrument>> INSTRUMENT_REGISTRY = registry("instrument", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCJukeboxSong>> JUKEBOX_SONG_REGISTRY = registry("jukebox_song", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCPoiType>> POI_TYPE_REGISTRY = registry("point_of_interest_type", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCPotion>> POTION_REGISTRY = registry("potion", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCVillagerProfession>> VILLAGER_PROFESSION_REGISTRY = registry("villager_profession", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCPaintingVariant>> PAINTING_VARIANT_REGISTRY = registry("painting_variant", new TypeToken<>() {});
-    MCCTypedKey<MCCRegistry<MCCEnchantment>> ENCHANTMENT_REGISTRY = registry("enchantment", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCInstrument>> INSTRUMENT_REGISTRY = dataDriven("instrument", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCJukeboxSong>> JUKEBOX_SONG_REGISTRY = dataDriven("jukebox_song", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCPaintingVariant>> PAINTING_VARIANT_REGISTRY = dataDriven("painting_variant", new TypeToken<>() {});
+    MCCTypedKey<MCCRegistry<MCCEnchantment>> ENCHANTMENT_REGISTRY = dataDriven("enchantment", new TypeToken<>() {});
 
-    private static <T> MCCTypedKey<T> registry(String registryKey, TypeToken<T> type) {
-        return MCCPlatform.getInstance().getTypedKeyFactory().getKey(Key.key("minecraft", registryKey), REGISTRY_OF_REGISTRIES, type);
+    private static <T> MCCTypedKey<T> dataDriven(String registryKey, TypeToken<T> type) {
+        return MCCPlatform.getInstance().getTypedKeyFactory().getRegistryKey(registryKey, type);
+    }
+
+    private static <T> MCCTypedKey<T> builtIn(String registryKey, TypeToken<T> type) {
+        return MCCPlatform.getInstance().getTypedKeyFactory().getRegistryKey(registryKey, type);
     }
 }

--- a/vanilla/src/main/java/de/verdox/mccreativelab/impl/vanilla/registry/NMSRegistry.java
+++ b/vanilla/src/main/java/de/verdox/mccreativelab/impl/vanilla/registry/NMSRegistry.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.key.Key;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
 import net.minecraft.core.WritableRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +19,12 @@ import java.util.*;
 import java.util.stream.Stream;
 
 public class NMSRegistry<T, R> extends MCCHandle<Registry<R>> implements MCCRegistry<T> {
-    public static final MCCConverter<Registry, NMSRegistry> CONVERTER = converter(NMSRegistry.class, Registry.class, NMSRegistry::new, registry -> (Registry) registry.getHandle());
+    public static final MCCConverter<Registry, NMSRegistry> CONVERTER = converter(NMSRegistry.class, Registry.class, registry -> {
+        if(registry.equals(BuiltInRegistries.REGISTRY)) {
+            return new NMSRootRegistry(registry);
+        }
+        return new NMSRegistry(registry);
+    }, registry -> (Registry) registry.getHandle());
     private final ConversionService conversionService;
 
     public NMSRegistry(Registry<R> handle) {

--- a/vanilla/src/main/java/de/verdox/mccreativelab/impl/vanilla/registry/NMSRootRegistry.java
+++ b/vanilla/src/main/java/de/verdox/mccreativelab/impl/vanilla/registry/NMSRootRegistry.java
@@ -1,0 +1,24 @@
+package de.verdox.mccreativelab.impl.vanilla.registry;
+
+import de.verdox.mccreativelab.wrapper.platform.MCCPlatform;
+import de.verdox.mccreativelab.wrapper.registry.MCCReference;
+import de.verdox.mccreativelab.wrapper.registry.MCCRegistry;
+import net.kyori.adventure.key.Key;
+import net.minecraft.core.Registry;
+
+import java.util.Optional;
+
+public class NMSRootRegistry extends NMSRegistry<MCCRegistry<?>, Registry<?>> {
+    public NMSRootRegistry(Registry<Registry<?>> handle) {
+        super(handle);
+    }
+
+    @Override
+    public Optional<MCCReference<MCCRegistry<?>>> getReference(Key key) {
+        try {
+            return Optional.of(wrapAsReference(MCCPlatform.getInstance().getRegistryStorage().getMinecraftRegistry(key)));
+        } catch (Throwable e) {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
The NMSRootRegistry object is a special case of NMSRegistry. We need this to have a special logic of getting the values associated with specific NMSTypedKeys that point at a Registry. Registries are found in different places based on their type. (Built-In / data driven)